### PR TITLE
add 'reconnect' setting and patch noVNC to fix issue after browser tab has been idle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PKG_VERSION := $(shell yq e ".version" manifest.yaml)
 TS_FILES := $(shell find ./ -name \*.ts)
 ROOT_FILES := $(shell find ./root)
 ASSET_FILES := $(shell find ./assets/compat)
+PATCH_FILES := $(shell find ./patches)
 
 .DELETE_ON_ERROR:
 
@@ -37,7 +38,7 @@ clean:
 scripts/embassy.js: $(TS_FILES)
 	deno bundle scripts/embassy.ts scripts/embassy.js
 
-docker-images/x86_64.tar: manifest.yaml Dockerfile docker_entrypoint.sh $(ROOT_FILES)
+docker-images/x86_64.tar: manifest.yaml Dockerfile docker_entrypoint.sh $(ROOT_FILES) $(PATCH_FILES)
 	mkdir -p docker-images
 	docker buildx build --tag start9/$(PKG_ID)/main:$(PKG_VERSION) \
 		--build-arg ARCH=x86_64 \

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -133,6 +133,13 @@ EOF
   fi
 fi
 
+# remove reference to non-existing file, see: https://github.com/linuxserver/kclient/issues/8
+sed -i '/<script src="public\/js\/pcm-player\.js"><\/script>/d' /kclient/public/index.html
+
+# add '&reconnect=' setting to kclient html
+RECONNECT=$(yq e '.reconnect' /root/data/start9/config.yaml)
+sed -i "s/\(index\.html?autoconnect=1\)/&\&reconnect=$RECONNECT/" /kclient/public/index.html
+
 # hack to disable systemd-inhibit, which Wasabi uses for sleep/shutdown detection
 # we don't need it, since we run in a container and don't use systemd or sleep the system.
 # this gets rid of a lot of repeated warning logs

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,9 @@
 id: wasabi-webtop
 title: "Wasabi"
-version: 2.2.1
+version: 2.2.1.1
 release-notes: |
-  * Update to Wasabi 2.2.1.0 - See [full changelog](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.2.1.0)
-  * Fix connecting to own Bitcoin Core P2P node
-  * Fix minor theme issues
+  * Add 'Automatically reconnect' option. Enable this to reconnect to the desktop when the connection is lost or the browser tab has been idle for too long.
+  * fix a minor issue when browser tab becomes idle (Cannot read properties of undefined (reading 'lastActiveAt'))
 license: MIT
 wrapper-repo: "https://github.com/remcoros/wasabi-webtop-startos"
 upstream-repo: "https://github.com/WalletWasabi/WalletWasabi"

--- a/patches/novnc.patch
+++ b/patches/novnc.patch
@@ -1,0 +1,54 @@
+diff --git a/app/ui.js b/app/ui.js
+index d973ffd..8d9515e 100644
+--- a/app/ui.js
++++ b/app/ui.js
+@@ -1628,15 +1628,17 @@ const UI = {
+         // UI.disconnect() won't be used in those cases.
+         UI.connected = false;
+ 
++        clearInterval(UI._sessionTimeoutInterval);
++
+         UI.rfb = undefined;
+ 
+         if (!e.detail.clean) {
+             UI.updateVisualState('disconnected');
+             if (wasConnected) {
+                 UI.showStatus(_("Something went wrong, connection is closed"),
+-                              'error');
++                              'error', 0, true);
+             } else {
+-                UI.showStatus(_("Failed to connect to server"), 'error');
++                UI.showStatus(_("Failed to connect to server"), 'error', 0, true);
+             }
+         } else if (UI.getSetting('reconnect', false) === true && !UI.inhibitReconnect) {
+             UI.updateVisualState('reconnecting');
+@@ -1646,7 +1648,7 @@ const UI = {
+             return;
+         } else {
+             UI.updateVisualState('disconnected');
+-            UI.showStatus(_("Disconnected"), 'normal');
++            UI.showStatus(_("Disconnected"), 'error', 0, true);
+         }
+ 
+         document.title = PAGE_TITLE;
+diff --git a/vnc.html b/vnc.html
+index e5b5177..565f273 100644
+--- a/vnc.html
++++ b/vnc.html
+@@ -478,13 +478,14 @@
+                                                 </div>
+                                             </li>
+                                             <li><hr></li>
+-                                            <li>
++                                            <li class="noVNC_hidden">
+                                                 <label class="switch">
+                                                     <input id="noVNC_setting_reconnect" type="checkbox"> 
++                                                    <span class="slider round"></span>
+                                                     <span class="slider-label">Automatic Reconnect</span>
+                                                 </label>
+                                             </li>
+-                                            <li>
++                                            <li class="noVNC_hidden">
+                                                 <label for="noVNC_setting_reconnect_delay">Reconnect Delay (ms):</label>
+                                                 <input id="noVNC_setting_reconnect_delay" type="number">
+                                             </li>

--- a/scripts/procedures/getConfig.ts
+++ b/scripts/procedures/getConfig.ts
@@ -38,6 +38,12 @@ export const [getConfig, setConfigMatcher] = compat.getConfigAndMatcher({
     "pattern-description": "Must not contain newline or quote characters.",
     copyable: true,
   },
+  reconnect: {
+    type: "boolean",
+    name: "Automatically reconnect",
+    description: "Automatically reconnect when the connection to the desktop is lost or the browser tab has been idle for too long.",
+    default: false,
+  },
   wasabi: {
     type: "object",
     name: "Wasabi settings",

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,4 +1,23 @@
 import { compat, types as T } from "../deps.ts";
 
 export const migration: T.ExpectedExports.migration = compat.migrations
-    .fromMapping({}, "2.2.1" );
+  .fromMapping({
+    "2.2.1.1": {
+      up: compat.migrations.updateConfig(
+        (config: any) => {
+          config["reconnect"] = false;
+          return config;
+        },
+        true,
+        { version: "2.2.1.1", type: "up" },
+      ),
+      down: compat.migrations.updateConfig(
+        (config: any) => {
+          delete config["reconnect"];
+          return config;
+        },
+        true,
+        { version: "2.2.1.1", type: "down" },
+      ),
+    },
+  }, "2.2.1.1");


### PR DESCRIPTION
explanation for reviewers:

The behavior of an idle tab has not changed by default. After being idle (for about 20 min.), kasm disconnects and shows a blue background.

But instead of running into a javascript error, it now correctly opens the kasm control bar, that allows to reconnect to the session (using the 'Connect' button):

![image](https://github.com/user-attachments/assets/1d69e36b-8c29-48d1-b7e2-3577857b29de)

this is still the default behavior (and preferred, so that a 'forgotten' tab does not eat resources for too long).

I've added an option "Automically reconnect", that makes use of the "reconnect" feature of kasm/noVNC. This automically reconnects to the session when it's closed either unexpected, or after idling for too long.

**Technicals:**

The main issue (kasm disconnects after a while, rendering a blue screen and the error `Uncaught TypeError: Cannot read properties of undefined`) is fixed by clearing the timer interval that kasm added when a disconnect happens. (this timer interval accesses "UI.rfb", but that is set to undefined when disconnected and causes a javascript error).

We clear the timer now, so that this error does not occur, and the intended logic of kasm/noVNC runs. (show a "disconnected message" and move the status to "disconnected" so that the kasm control bar opens)

Also added 'noVNC_hidden' css class to the reconnect options in kasm control bar, as this is now controlled from StartOS.