### PR TITLE
Minor fixes (see description)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN \
   cp index.html vnc.html && \
   mkdir Downloads
 
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm-7784e3cf-ls114 AS buildstage
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm-9d98b2d5-ls120 AS buildstage
 
 # these are specified in Makefile
 ARG ARCH
@@ -81,8 +81,6 @@ RUN \
   DEBIAN_FRONTEND=noninteractive \
   apt-get remove --purge --autoremove -y \
     containerd.io \
-    cpp \
-    cpp-12 \
     docker-ce \
     docker-ce-cli \
     docker-buildx-plugin \

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,9 +1,9 @@
 id: wasabi-webtop
 title: "Wasabi"
-version: 2.6.0
+version: 2.6.0.1
 release-notes: |
-  * Update to Wasabi 2.6.0 - See [full changelog](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.6.0)
-  * NEW! Connect to your StartOS Bitcoin node
+  * Fixed a UI glitch by presetting the webtop screen resolution.
+  * Update KASM base container image to the latest version.
 license: MIT
 wrapper-repo: "https://github.com/remcoros/wasabi-webtop-startos"
 upstream-repo: "https://github.com/WalletWasabi/WalletWasabi"

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,4 +1,7 @@
 # run a compositor to get transparency effects
 xcompmgr -c &
 
-dbus-launch wassabee
+# Work around UI glitch in Wasabi by presetting the screen resolution
+xrandr --output VNC-0 --mode 1920x1080
+
+wassabee

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -6,4 +6,4 @@ export NO_AT_BRIDGE=1
 setterm blank 0
 setterm powerdown 0
 
-/usr/bin/openbox-session > /dev/null 2>&1
+/usr/bin/openbox-session

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -42,5 +42,5 @@ export const migration: T.ExpectedExports.migration =
         ),
       },
     },
-    "2.6.0"
+    "2.6.0.1"
   );


### PR DESCRIPTION
- workaround a UI glitch
- update kasm base container
- do not send logs to null (so we can see wasabi logs in startos)